### PR TITLE
Some Refactoring on QDjangoUrlResolver

### DIFF
--- a/src/http/QDjangoUrlResolver.cpp
+++ b/src/http/QDjangoUrlResolver.cpp
@@ -55,7 +55,7 @@ QDjangoHttpResponse* QDjangoUrlResolverPrivate::respond(const QDjangoHttpRequest
         if (it->urls && it->path.indexIn(path) == 0) {
             // try recursing
             QString subPath = path.mid(it->path.capturedTexts().first().size());
-            QDjangoHttpResponse *response = it->urls->d->respond(request, subPath);
+            QDjangoHttpResponse *response = it->urls->respond(request, subPath);
             if (response)
                 return response;
         } else if (it->receiver && it->path.exactMatch(path)) {

--- a/src/http/QDjangoUrlResolver.h
+++ b/src/http/QDjangoUrlResolver.h
@@ -42,10 +42,8 @@ public:
 
     bool include(const QRegExp &path, QDjangoUrlResolver *urls);
     bool set(const QRegExp &path, QObject *receiver, const char *member);
-    QString reverse(QObject *receiver, const char *member, const QVariantList &args = QVariantList()) const;
-
-public slots:
-    QDjangoHttpResponse* respond(const QDjangoHttpRequest &request, const QString &path) const;
+    virtual QString reverse(QObject *receiver, const char *member, const QVariantList &args = QVariantList()) const;
+    virtual QDjangoHttpResponse* respond(const QDjangoHttpRequest &request, const QString &path) const;
 
 private:
     QDjangoUrlResolverPrivate *d;


### PR DESCRIPTION
Added virtual keyword to methods reverse and respond, and
removed "public slots:" never used as slots;
