### PR TITLE
Included setBody method to use on WebView and NetworkAccessManager.

### DIFF
--- a/src/db/QDjango.cpp
+++ b/src/db/QDjango.cpp
@@ -29,7 +29,7 @@
 static const char *connectionPrefix = "_qdjango_";
 
 QMap<QByteArray, QDjangoMetaModel> globalMetaModels = QMap<QByteArray, QDjangoMetaModel>();
-static QDjangoDatabase *globalDatabase = 0;
+static QDjangoDatabase *globalDatabase = NULL;
 static bool globalDebugEnabled = false;
 
 /// \cond
@@ -56,7 +56,9 @@ void QDjangoDatabase::threadFinished()
 
 static void closeDatabase()
 {
-    delete globalDatabase;
+    if (globalDatabase)
+        delete globalDatabase;
+    globalDatabase = NULL;
 }
 
 static void initDatabase(QSqlDatabase db)

--- a/src/http/QDjangoHttpRequest.cpp
+++ b/src/http/QDjangoHttpRequest.cpp
@@ -76,11 +76,29 @@ QString QDjangoHttpRequest::meta(const QString &key) const
     return d->meta.value(key);
 }
 
+/** Insert meta information.
+ *
+ * \param key
+ * \param value
+ */
+void QDjangoHttpRequest::insertMeta(const QString &key, const QString &value)
+{
+    d->meta.insert(key, value);
+}
+
 /** Returns the HTTP request's method (e.g. GET, POST).
  */
 QString QDjangoHttpRequest::method() const
 {
     return d->method;
+}
+
+/** Sets the HTTP request's method (e.g. GET, POST).
+ * \param method
+ */
+void QDjangoHttpRequest::setMethod(const QString &method)
+{
+    d->method = method;
 }
 
 /** Returns the HTTP request's path.

--- a/src/http/QDjangoHttpRequest.cpp
+++ b/src/http/QDjangoHttpRequest.cpp
@@ -46,6 +46,11 @@ QByteArray QDjangoHttpRequest::body() const
     return d->buffer;
 }
 
+void QDjangoHttpRequest::setBody(const QByteArray &body)
+{
+    d->buffer = body;
+}
+
 /** Returns the GET data for the given \a key.
  */
 QString QDjangoHttpRequest::get(const QString &key) const

--- a/src/http/QDjangoHttpRequest.h
+++ b/src/http/QDjangoHttpRequest.h
@@ -38,7 +38,9 @@ public:
     void setBody(const QByteArray &body);
     QString get(const QString &key) const;
     QString meta(const QString &key) const;
+    void insertMeta(const QString &key, const QString &value);
     QString method() const;
+    void setMethod(const QString &method);
     QString path() const;
     QString post(const QString &key) const;
 

--- a/src/http/QDjangoHttpRequest.h
+++ b/src/http/QDjangoHttpRequest.h
@@ -35,6 +35,7 @@ public:
     ~QDjangoHttpRequest();
 
     QByteArray body() const;
+    void setBody(const QByteArray &body);
     QString get(const QString &key) const;
     QString meta(const QString &key) const;
     QString method() const;


### PR DESCRIPTION
Hi,
I'm working on a desktop application using a WebKit WebView. I'm using QDjangoUrlResolver to deal with routes from WebView requests. I wrote a custom NetworkAccessManager where I translate default QNetworkRequest (and the request body that comes on an QIODevice pointer) to QDjangoHttpRequest, then I invoke QDjangoUrlResolver::respond to do stuff. At the end, I translate QDjangoHttpResponse to QHttpResponse.
Thanks,
ofrankmartin
