### PR TITLE
refactor test structure

### DIFF
--- a/tests/db/auth/auth.pro
+++ b/tests/db/auth/auth.pro
@@ -1,3 +1,4 @@
+DEPTH = ../../..
 include(../db.pri)
 
 TARGET = tst_auth

--- a/tests/db/db.pri
+++ b/tests/db/db.pri
@@ -1,10 +1,11 @@
 include(../../qdjango.pri)
+include(../../tests/tests.pri)
 
-QT -= gui
-QT += sql testlib
+QT += sql
+LIBS += -L$${DEPTH}/src/db $${QDJANGO_DB_LIBS}
+INCLUDEPATH += $${PWD}
 
-HEADERS += $$PWD/util.h
-SOURCES += $$PWD/util.cpp
-INCLUDEPATH += $$PWD $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/db $$QDJANGO_DB_LIBS
+HEADERS += \
+    $$PWD/util.h
+SOURCES += \
+    $$PWD/util.cpp

--- a/tests/db/qdjango/qdjango.pro
+++ b/tests/db/qdjango/qdjango.pro
@@ -1,3 +1,5 @@
+DEPTH = ../../..
 include(../db.pri)
+
 TARGET = tst_qdjango
 SOURCES += tst_qdjango.cpp

--- a/tests/db/qdjango/tst_qdjango.cpp
+++ b/tests/db/qdjango/tst_qdjango.cpp
@@ -99,6 +99,12 @@ void tst_QDjango::cleanup()
 
 void tst_QDjango::databaseThreaded()
 {
+    if (QDjango::database().databaseName() == QLatin1String(":memory:")) {
+        QEXPECT_FAIL("", "Threaded mode not supported with sqlite memory database", Continue);
+        QVERIFY(false);
+        return;
+    }
+
     QDjangoQuerySet<Author> qs;
     QCOMPARE(qs.count(), 0);
 

--- a/tests/db/qdjangocompiler/qdjangocompiler.pro
+++ b/tests/db/qdjangocompiler/qdjangocompiler.pro
@@ -1,3 +1,5 @@
+DEPTH = ../../..
 include(../db.pri)
+
 TARGET = tst_qdjangocompiler
 SOURCES += tst_qdjangocompiler.cpp

--- a/tests/db/qdjangometamodel/qdjangometamodel.pro
+++ b/tests/db/qdjangometamodel/qdjangometamodel.pro
@@ -1,3 +1,4 @@
+DEPTH = ../../..
 include(../db.pri)
 
 TARGET = tst_qdjangometamodel

--- a/tests/db/qdjangomodel/qdjangomodel.pro
+++ b/tests/db/qdjangomodel/qdjangomodel.pro
@@ -1,3 +1,4 @@
+DEPTH = ../../..
 include(../db.pri)
 
 TARGET = tst_qdjangomodel

--- a/tests/db/qdjangoqueryset/qdjangoqueryset.pro
+++ b/tests/db/qdjangoqueryset/qdjangoqueryset.pro
@@ -1,8 +1,5 @@
+DEPTH = ../../..
 include(../db.pri)
 
 TARGET = tst_qdjangoqueryset
 SOURCES += tst_qdjangoqueryset.cpp
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/db $$QDJANGO_DB_LIBS

--- a/tests/db/qdjangowhere/qdjangowhere.pro
+++ b/tests/db/qdjangowhere/qdjangowhere.pro
@@ -1,3 +1,4 @@
+DEPTH = ../../..
 include(../db.pri)
 
 TARGET = tst_qdjangowhere

--- a/tests/db/shares/shares.pro
+++ b/tests/db/shares/shares.pro
@@ -1,3 +1,4 @@
+DEPTH = ../../..
 include(../db.pri)
 
 TARGET = tst_shares

--- a/tests/http/http.pri
+++ b/tests/http/http.pri
@@ -1,0 +1,5 @@
+include(../../qdjango.pri)
+include(../../tests/tests.pri)
+
+QT += network
+LIBS += -L$${DEPTH}/src/http $${QDJANGO_HTTP_LIBS}

--- a/tests/http/qdjangofastcgiserver/qdjangofastcgiserver.pro
+++ b/tests/http/qdjangofastcgiserver/qdjangofastcgiserver.pro
@@ -1,12 +1,5 @@
-include(../../../qdjango.pri)
-
-QT -= gui
-QT += network testlib
+DEPTH = ../../..
+include(../http.pri)
 
 TARGET = tst_qdjangofastcgiserver
-
 SOURCES += tst_qdjangofastcgiserver.cpp
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/http $$QDJANGO_HTTP_LIBS

--- a/tests/http/qdjangohttpcontroller/qdjangohttpcontroller.pro
+++ b/tests/http/qdjangohttpcontroller/qdjangohttpcontroller.pro
@@ -1,13 +1,6 @@
-include(../../../qdjango.pri)
-
-QT -= gui
-QT += network testlib
+DEPTH = ../../..
+include(../http.pri)
 
 TARGET = tst_qdjangohttpcontroller
-
 SOURCES += tst_qdjangohttpcontroller.cpp
 RESOURCES += tst_qdjangohttpcontroller.qrc
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/http $$QDJANGO_HTTP_LIBS

--- a/tests/http/qdjangohttprequest/qdjangohttprequest.pro
+++ b/tests/http/qdjangohttprequest/qdjangohttprequest.pro
@@ -1,12 +1,5 @@
-include(../../../qdjango.pri)
-
-QT -= gui
-QT += network testlib
+DEPTH = ../../..
+include(../http.pri)
 
 TARGET = tst_qdjangohttprequest
-
 SOURCES += tst_qdjangohttprequest.cpp
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/http $$QDJANGO_HTTP_LIBS

--- a/tests/http/qdjangohttpresponse/qdjangohttpresponse.pro
+++ b/tests/http/qdjangohttpresponse/qdjangohttpresponse.pro
@@ -1,12 +1,5 @@
-include(../../../qdjango.pri)
-
-QT -= gui
-QT += network testlib
+DEPTH = ../../..
+include(../http.pri)
 
 TARGET = tst_qdjangohttpresponse
-
 SOURCES += tst_qdjangohttpresponse.cpp
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/http $$QDJANGO_HTTP_LIBS

--- a/tests/http/qdjangohttpserver/qdjangohttpserver.pro
+++ b/tests/http/qdjangohttpserver/qdjangohttpserver.pro
@@ -1,12 +1,5 @@
-include(../../../qdjango.pri)
-
-QT -= gui
-QT += network testlib
+DEPTH = ../../..
+include(../http.pri)
 
 TARGET = tst_qdjangohttpserver
-
 SOURCES += tst_qdjangohttpserver.cpp
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/http $$QDJANGO_HTTP_LIBS

--- a/tests/http/qdjangourlresolver/qdjangourlresolver.pro
+++ b/tests/http/qdjangourlresolver/qdjangourlresolver.pro
@@ -1,12 +1,5 @@
-include(../../../qdjango.pri)
-
-QT -= gui
-QT += network testlib
+DEPTH = ../../..
+include(../http.pri)
 
 TARGET = tst_qdjangourlresolver
-
 SOURCES += tst_qdjangourlresolver.cpp
-
-INCLUDEPATH += $$QDJANGO_INCLUDEPATH
-
-LIBS += -L../../../src/http $$QDJANGO_HTTP_LIBS

--- a/tests/script/qdjangoscript/qdjangoscript.pro
+++ b/tests/script/qdjangoscript/qdjangoscript.pro
@@ -1,15 +1,14 @@
-include(../../../qdjango.pri)
+DEPTH = ../../..
+include($${DEPTH}/qdjango.pri)
+include($${DEPTH}/tests/tests.pri)
 
-QT -= gui
-QT += script sql testlib
+QT += script sql
 
 TARGET = tst_qdjangoscript
-
 HEADERS += ../../db/auth-models.h ../../db/util.h
 SOURCES += ../../db/auth-models.cpp ../../db/util.cpp tst_qdjangoscript.cpp
 
 INCLUDEPATH += ../../db $$QDJANGO_INCLUDEPATH
-
 LIBS += \
-    -L../../../src/db $$QDJANGO_DB_LIBS \
-    -L../../../src/script $$QDJANGO_SCRIPT_LIBS
+    -L$${DEPTH}/src/db $${QDJANGO_DB_LIBS} \
+    -L$${DEPTH}/src/script $${QDJANGO_SCRIPT_LIBS}

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -1,0 +1,5 @@
+INCLUDEPATH += $${QDJANGO_INCLUDEPATH}
+QT += core testlib
+QT -= gui
+CONFIG -= app_bundle
+CONFIG += testcase


### PR DESCRIPTION
The changes included here allow for tests to be run in shadow builds,
as well as by using "make check" rather than the custom run.py script. I've
also added an expected fail for tst_qdjango in the case where an in-memory
database is being used for sqlite (the default case)
