### PR TITLE
add support for detecting dialects

### DIFF
--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -273,7 +273,9 @@ bool QDjangoQuerySetPrivate::sqlInsert(const QVariantMap &fields, QVariant *inse
     // fetch autoincrement pk
     if (insertId) {
         QSqlDatabase db = QDjango::database();
-        if (db.driverName() == QLatin1String("QPSQL")) {
+        QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(db);
+
+        if (dialect == QDjangoDatabase::PSQL) {
             const QDjangoMetaModel metaModel = QDjango::metaModel(m_modelName);
             QDjangoQuery query(db);
             const QDjangoMetaField primaryKey = metaModel.localField("pk");

--- a/src/db/QDjangoWhere.cpp
+++ b/src/db/QDjangoWhere.cpp
@@ -198,7 +198,7 @@ QDjangoWhere QDjangoWhere::operator!() const
     } else {
         result.d->negate = !d->negate;
     }
-    
+
     return result;
 }
 
@@ -300,6 +300,8 @@ bool QDjangoWhere::isNone() const
  */
 QString QDjangoWhere::sql(const QSqlDatabase &db) const
 {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(db);
+
     switch (d->operation) {
         case Equals:
             return d->key + QLatin1String(" = ?");
@@ -330,11 +332,11 @@ QString QDjangoWhere::sql(const QSqlDatabase &db) const
         case Contains:
         {
             QString op;
-            if (db.driverName() == QLatin1String("QMYSQL"))
+            if (dialect == QDjangoDatabase::MYSQL)
                 op = QLatin1String(d->negate ? "NOT LIKE BINARY" : "LIKE BINARY");
             else
                 op = QLatin1String(d->negate ? "NOT LIKE" : "LIKE");
-            if (db.driverName() == QLatin1String("QSQLITE") || db.driverName() == QLatin1String("QSQLITE2"))
+            if (dialect == QDjangoDatabase::SQLITE)
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ? ESCAPE '\\'");
             else
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ?");
@@ -345,9 +347,9 @@ QString QDjangoWhere::sql(const QSqlDatabase &db) const
         case IEquals:
         {
             const QString op = QLatin1String(d->negate ? "NOT LIKE" : "LIKE");
-            if (db.driverName() == QLatin1String("QSQLITE") || db.driverName() == QLatin1String("QSQLITE2"))
+            if (dialect == QDjangoDatabase::SQLITE)
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ? ESCAPE '\\'");
-            else if (db.driverName() == QLatin1String("QPSQL"))
+            else if (dialect == QDjangoDatabase::PSQL)
                 return QLatin1String("UPPER(") + d->key + QLatin1String("::text) ") + op + QLatin1String(" UPPER(?)");
             else
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ?");
@@ -355,9 +357,9 @@ QString QDjangoWhere::sql(const QSqlDatabase &db) const
         case INotEquals:
         {
             const QString op = QLatin1String(d->negate ? "LIKE" : "NOT LIKE");
-            if (db.driverName() == QLatin1String("QSQLITE") || db.driverName() == QLatin1String("QSQLITE2"))
+            if (dialect == QDjangoDatabase::SQLITE)
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ? ESCAPE '\\'");
-            else if (db.driverName() == QLatin1String("QPSQL"))
+            else if (dialect == QDjangoDatabase::PSQL)
                 return QLatin1String("UPPER(") + d->key + QLatin1String("::text) ") + op + QLatin1String(" UPPER(?)");
             else
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ?");

--- a/src/db/QDjango_p.h
+++ b/src/db/QDjango_p.h
@@ -48,6 +48,15 @@ class QDjangoDatabase : public QObject
 public:
     QDjangoDatabase(QObject *parent = 0);
 
+    enum Dialect {
+        UnknownDialect,
+        SQLITE,
+        MYSQL,
+        PSQL
+    };
+
+    static Dialect databaseDialect(const QSqlDatabase &db);
+
     QSqlDatabase reference;
     QMutex mutex;
     QMap<QThread*, QSqlDatabase> copies;

--- a/tests/db/qdjangometamodel/tst_qdjangometamodel.cpp
+++ b/tests/db/qdjangometamodel/tst_qdjangometamodel.cpp
@@ -116,10 +116,10 @@ void tst_QDjangoMetaModel::initTestCase()
 void tst_QDjangoMetaModel::testBool()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_bool\" (\"id\" serial PRIMARY KEY, \"value\" boolean NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_bool` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` bool NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_bool\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" bool NOT NULL)");
@@ -133,10 +133,10 @@ void tst_QDjangoMetaModel::testBool()
 void tst_QDjangoMetaModel::testByteArray()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_bytearray\" (\"id\" serial PRIMARY KEY, \"value\" bytea NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_bytearray` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` blob NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_bytearray\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" blob NOT NULL)");
@@ -150,10 +150,10 @@ void tst_QDjangoMetaModel::testByteArray()
 void tst_QDjangoMetaModel::testDate()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_date\" (\"id\" serial PRIMARY KEY, \"value\" date NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_date` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` date NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_date\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" date NOT NULL)");
@@ -166,10 +166,10 @@ void tst_QDjangoMetaModel::testDate()
 void tst_QDjangoMetaModel::testDateTime()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_datetime\" (\"id\" serial PRIMARY KEY, \"value\" timestamp NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_datetime` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` datetime NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_datetime\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" datetime NOT NULL)");
@@ -182,10 +182,10 @@ void tst_QDjangoMetaModel::testDateTime()
 void tst_QDjangoMetaModel::testDouble()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_double\" (\"id\" serial PRIMARY KEY, \"value\" real NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_double` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` real NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_double\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" real NOT NULL)");
@@ -198,10 +198,10 @@ void tst_QDjangoMetaModel::testDouble()
 void tst_QDjangoMetaModel::testInteger()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_integer\" (\"id\" serial PRIMARY KEY, \"value\" integer NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_integer` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` integer NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_integer\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" integer NOT NULL)");
@@ -216,10 +216,10 @@ void tst_QDjangoMetaModel::testInteger()
 void tst_QDjangoMetaModel::testLongLong()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_longlong\" (\"id\" serial PRIMARY KEY, \"value\" bigint NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_longlong` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` bigint NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_longlong\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" bigint NOT NULL)");
@@ -234,10 +234,10 @@ void tst_QDjangoMetaModel::testLongLong()
 void tst_QDjangoMetaModel::testString()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_string\" (\"id\" serial PRIMARY KEY, \"value\" varchar(255) NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_string` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` varchar(255) NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_string\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" varchar(255) NOT NULL)");
@@ -250,10 +250,10 @@ void tst_QDjangoMetaModel::testString()
 void tst_QDjangoMetaModel::testTime()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL"))
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL)
         sql << QLatin1String("CREATE TABLE \"tst_time\" (\"id\" serial PRIMARY KEY, \"value\" time NOT NULL)");
-    else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-             QDjango::database().driverName() == QLatin1String("QMYSQL3"))
+    else if (dialect == QDjangoDatabase::MYSQL)
         sql << QLatin1String("CREATE TABLE `tst_time` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` time NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_time\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" time NOT NULL)");
@@ -266,7 +266,8 @@ void tst_QDjangoMetaModel::testTime()
 void tst_QDjangoMetaModel::testOptions()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL) {
         sql << QLatin1String(
             "CREATE TABLE \"some_table\" ("
                 "\"id\" serial PRIMARY KEY, "
@@ -279,8 +280,7 @@ void tst_QDjangoMetaModel::testOptions()
                 "UNIQUE (\"aField\", \"b_field\")"
             ")");
         sql << QLatin1String("CREATE INDEX \"some_table_ac243651\" ON \"some_table\" (\"indexField\")");
-    } else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-               QDjango::database().driverName() == QLatin1String("QMYSQL3")) {
+    } else if (dialect == QDjangoDatabase::MYSQL) {
         sql << QLatin1String(
             "CREATE TABLE `some_table` ("
                 "`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, "
@@ -356,7 +356,8 @@ void tst_QDjangoMetaModel::testOptions()
 void tst_QDjangoMetaModel::testConstraints()
 {
     QStringList sql;
-    if (QDjango::database().driverName() == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL) {
         sql << QLatin1String("CREATE TABLE \"tst_fkconstraint\" ("
             "\"id\" serial PRIMARY KEY, "
             "\"noConstraint_id\" integer NOT NULL REFERENCES \"user\" (\"id\") DEFERRABLE INITIALLY DEFERRED, "
@@ -368,8 +369,7 @@ void tst_QDjangoMetaModel::testConstraints()
         sql << QLatin1String("CREATE INDEX \"tst_fkconstraint_4634d592\" ON \"tst_fkconstraint\" (\"cascadeConstraint_id\")");
         sql << QLatin1String("CREATE INDEX \"tst_fkconstraint_728cefe1\" ON \"tst_fkconstraint\" (\"restrictConstraint_id\")");
         sql << QLatin1String("CREATE INDEX \"tst_fkconstraint_44c71620\" ON \"tst_fkconstraint\" (\"nullConstraint_id\")");
-    } else if (QDjango::database().driverName() == QLatin1String("QMYSQL") ||
-               QDjango::database().driverName() == QLatin1String("QMYSQL3")) {
+    } else if (dialect == QDjangoDatabase::MYSQL) {
         sql << QLatin1String("CREATE TABLE `tst_fkconstraint` ("
             "`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, "
             "`noConstraint_id` integer NOT NULL, "

--- a/tests/db/qdjangowhere/tst_qdjangowhere.cpp
+++ b/tests/db/qdjangowhere/tst_qdjangowhere.cpp
@@ -91,8 +91,8 @@ void tst_QDjangoWhere::equalsWhere()
   */
 void tst_QDjangoWhere::iEqualsWhere()
 {
-    QString driverName = QDjango::database().driverName();
-     if (driverName == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+     if (dialect == QDjangoDatabase::PSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IEquals, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "abc");
 
@@ -127,8 +127,8 @@ void tst_QDjangoWhere::notEqualsWhere()
   */
 void tst_QDjangoWhere::iNotEqualsWhere()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::INotEquals, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) NOT LIKE UPPER(?)"), QVariantList() << "abc");
 
@@ -224,8 +224,8 @@ void tst_QDjangoWhere::isNull()
  */
 void tst_QDjangoWhere::startsWith()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QMYSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::MYSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::StartsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "abc%");
 
@@ -246,8 +246,8 @@ void tst_QDjangoWhere::startsWith()
 
 void tst_QDjangoWhere::iStartsWith()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IStartsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "abc%");
 
@@ -266,8 +266,8 @@ void tst_QDjangoWhere::iStartsWith()
  */
 void tst_QDjangoWhere::endsWith()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QMYSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::MYSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::EndsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "%abc");
 
@@ -287,8 +287,8 @@ void tst_QDjangoWhere::endsWith()
 
 void tst_QDjangoWhere::iEndsWith()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IEndsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "%abc");
 
@@ -309,8 +309,8 @@ void tst_QDjangoWhere::iEndsWith()
  */
 void tst_QDjangoWhere::contains()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QMYSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::MYSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::Contains, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "%abc%");
 
@@ -330,8 +330,8 @@ void tst_QDjangoWhere::contains()
 
 void tst_QDjangoWhere::iContains()
 {
-    QString driverName = QDjango::database().driverName();
-    if (driverName == QLatin1String("QPSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::PSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IContains, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "%abc%");
 

--- a/tests/db/util.cpp
+++ b/tests/db/util.cpp
@@ -35,18 +35,18 @@ bool initialiseDatabase()
         databaseDriver = QString::fromLocal8Bit(p);
     QSqlDatabase db = QSqlDatabase::addDatabase(databaseDriver);
 
-    if ((p = getenv("QDJANGO_DB_NAME")) != 0) 
+    if ((p = getenv("QDJANGO_DB_NAME")) != 0)
         db.setDatabaseName(QString::fromLocal8Bit(p));
     else if (databaseDriver == "QSQLITE")
         db.setDatabaseName(":memory:");
 
-    if ((p = getenv("QDJANGO_DB_USER")) != 0) 
+    if ((p = getenv("QDJANGO_DB_USER")) != 0)
         db.setUserName(QString::fromLocal8Bit(p));
-    
-    if ((p = getenv("QDJANGO_DB_PASSWORD")) != 0) 
+
+    if ((p = getenv("QDJANGO_DB_PASSWORD")) != 0)
         db.setPassword(QString::fromLocal8Bit(p));
-    
-    if ((p = getenv("QDJANGO_DB_HOST")) != 0) 
+
+    if ((p = getenv("QDJANGO_DB_HOST")) != 0)
         db.setHostName(QString::fromLocal8Bit(p));
 
     if (db.open()) {
@@ -59,11 +59,13 @@ bool initialiseDatabase()
 
 QString normalizeSql(const QSqlDatabase &db, const QString &sql)
 {
-    const QString driverName = db.driverName();
+    QDjangoDatabase::Dialect dialect =
+        QDjangoDatabase::databaseDialect(db);
+
     QString modSql(sql);
-    if (driverName == "QMYSQL")
+    if (dialect == QDjangoDatabase::MYSQL)
         modSql.replace("`", "\"");
-    else if (driverName == "QSQLITE" || driverName == "QSQLITE2")
+    else if (dialect == QDjangoDatabase::SQLITE)
         modSql.replace("? ESCAPE '\\'", "?");
     return modSql;
 }

--- a/tests/script/qdjangoscript/tst_qdjangoscript.cpp
+++ b/tests/script/qdjangoscript/tst_qdjangoscript.cpp
@@ -90,7 +90,8 @@ void tst_QDjangoScript::testWhereConstructor()
     where = engine->fromScriptValue<QDjangoWhere>(result);
     CHECKWHERE(where, QLatin1String("username >= ?"), QVariantList() << "foobar");
 
-    if (QDjango::database().driverName() == QLatin1String("QMYSQL")) {
+    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
+    if (dialect == QDjangoDatabase::MYSQL) {
         // starts with
         result = engine->evaluate("Q({'username__startswith': 'foobar'})");
         where = engine->fromScriptValue<QDjangoWhere>(result);


### PR DESCRIPTION
This may originally seem like a superfluous change, however I'm
currently testing with ODBC drivers, and the driverName() of the
database is no longer sufficient for determining differences in
database dialects throughout the codebase. This change allows for
injecting logic to determine the dialect in the event the user
is not using a native driver.
