### PR TITLE
refactor dialect changes

### DIFF
--- a/src/db/QDjangoMetaModel.cpp
+++ b/src/db/QDjangoMetaModel.cpp
@@ -438,7 +438,7 @@ QStringList QDjangoMetaModel::createTableSql() const
 {
     QSqlDatabase db = QDjango::database();
     QSqlDriver *driver = db.driver();
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
 
     QStringList queries;
     QStringList propSql;

--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -273,7 +273,7 @@ bool QDjangoQuerySetPrivate::sqlInsert(const QVariantMap &fields, QVariant *inse
     // fetch autoincrement pk
     if (insertId) {
         QSqlDatabase db = QDjango::database();
-        QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
+        QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
 
         if (databaseType == QDjangoDatabase::PostgreSQL) {
             const QDjangoMetaModel metaModel = QDjango::metaModel(m_modelName);

--- a/src/db/QDjangoWhere.cpp
+++ b/src/db/QDjangoWhere.cpp
@@ -300,7 +300,7 @@ bool QDjangoWhere::isNone() const
  */
 QString QDjangoWhere::sql(const QSqlDatabase &db) const
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
 
     switch (d->operation) {
         case Equals:

--- a/src/db/QDjango_p.h
+++ b/src/db/QDjango_p.h
@@ -60,12 +60,14 @@ public:
         DB2
     };
 
+    static DatabaseType databaseType();
     static DatabaseType databaseType(const QSqlDatabase &db);
 
     QSqlDatabase reference;
     QMutex mutex;
     QMap<QThread*, QSqlDatabase> copies;
     qint64 connectionId;
+    DatabaseType type;
 
 private slots:
     void threadFinished();

--- a/tests/db/qdjangometamodel/tst_qdjangometamodel.cpp
+++ b/tests/db/qdjangometamodel/tst_qdjangometamodel.cpp
@@ -116,7 +116,7 @@ void tst_QDjangoMetaModel::initTestCase()
 void tst_QDjangoMetaModel::testBool()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_bool\" (\"id\" serial PRIMARY KEY, \"value\" boolean NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -133,7 +133,7 @@ void tst_QDjangoMetaModel::testBool()
 void tst_QDjangoMetaModel::testByteArray()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_bytearray\" (\"id\" serial PRIMARY KEY, \"value\" bytea NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -150,7 +150,7 @@ void tst_QDjangoMetaModel::testByteArray()
 void tst_QDjangoMetaModel::testDate()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_date\" (\"id\" serial PRIMARY KEY, \"value\" date NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -166,7 +166,7 @@ void tst_QDjangoMetaModel::testDate()
 void tst_QDjangoMetaModel::testDateTime()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_datetime\" (\"id\" serial PRIMARY KEY, \"value\" timestamp NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -182,7 +182,7 @@ void tst_QDjangoMetaModel::testDateTime()
 void tst_QDjangoMetaModel::testDouble()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_double\" (\"id\" serial PRIMARY KEY, \"value\" real NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -198,7 +198,7 @@ void tst_QDjangoMetaModel::testDouble()
 void tst_QDjangoMetaModel::testInteger()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_integer\" (\"id\" serial PRIMARY KEY, \"value\" integer NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -216,7 +216,7 @@ void tst_QDjangoMetaModel::testInteger()
 void tst_QDjangoMetaModel::testLongLong()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_longlong\" (\"id\" serial PRIMARY KEY, \"value\" bigint NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -234,7 +234,7 @@ void tst_QDjangoMetaModel::testLongLong()
 void tst_QDjangoMetaModel::testString()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_string\" (\"id\" serial PRIMARY KEY, \"value\" varchar(255) NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -250,7 +250,7 @@ void tst_QDjangoMetaModel::testString()
 void tst_QDjangoMetaModel::testTime()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_time\" (\"id\" serial PRIMARY KEY, \"value\" time NOT NULL)");
     else if (databaseType == QDjangoDatabase::MySqlServer)
@@ -266,7 +266,7 @@ void tst_QDjangoMetaModel::testTime()
 void tst_QDjangoMetaModel::testOptions()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL) {
         sql << QLatin1String(
             "CREATE TABLE \"some_table\" ("
@@ -356,7 +356,7 @@ void tst_QDjangoMetaModel::testOptions()
 void tst_QDjangoMetaModel::testConstraints()
 {
     QStringList sql;
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL) {
         sql << QLatin1String("CREATE TABLE \"tst_fkconstraint\" ("
             "\"id\" serial PRIMARY KEY, "

--- a/tests/db/qdjangowhere/tst_qdjangowhere.cpp
+++ b/tests/db/qdjangowhere/tst_qdjangowhere.cpp
@@ -91,7 +91,7 @@ void tst_QDjangoWhere::equalsWhere()
   */
 void tst_QDjangoWhere::iEqualsWhere()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
      if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IEquals, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "abc");
@@ -127,7 +127,7 @@ void tst_QDjangoWhere::notEqualsWhere()
   */
 void tst_QDjangoWhere::iNotEqualsWhere()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::INotEquals, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) NOT LIKE UPPER(?)"), QVariantList() << "abc");
@@ -224,7 +224,7 @@ void tst_QDjangoWhere::isNull()
  */
 void tst_QDjangoWhere::startsWith()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::MySqlServer) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::StartsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "abc%");
@@ -246,7 +246,7 @@ void tst_QDjangoWhere::startsWith()
 
 void tst_QDjangoWhere::iStartsWith()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IStartsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "abc%");
@@ -266,7 +266,7 @@ void tst_QDjangoWhere::iStartsWith()
  */
 void tst_QDjangoWhere::endsWith()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::MySqlServer) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::EndsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "%abc");
@@ -287,7 +287,7 @@ void tst_QDjangoWhere::endsWith()
 
 void tst_QDjangoWhere::iEndsWith()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IEndsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "%abc");
@@ -309,7 +309,7 @@ void tst_QDjangoWhere::iEndsWith()
  */
 void tst_QDjangoWhere::contains()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::MySqlServer) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::Contains, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "%abc%");
@@ -330,7 +330,7 @@ void tst_QDjangoWhere::contains()
 
 void tst_QDjangoWhere::iContains()
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IContains, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "%abc%");

--- a/tests/db/util.cpp
+++ b/tests/db/util.cpp
@@ -59,7 +59,8 @@ bool initialiseDatabase()
 
 QString normalizeSql(const QSqlDatabase &db, const QString &sql)
 {
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
+    Q_UNUSED(db);
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     QString modSql(sql);
     if (databaseType == QDjangoDatabase::MySqlServer)
         modSql.replace("`", "\"");

--- a/tests/script/qdjangoscript/tst_qdjangoscript.cpp
+++ b/tests/script/qdjangoscript/tst_qdjangoscript.cpp
@@ -90,7 +90,7 @@ void tst_QDjangoScript::testWhereConstructor()
     where = engine->fromScriptValue<QDjangoWhere>(result);
     CHECKWHERE(where, QLatin1String("username >= ?"), QVariantList() << "foobar");
 
-    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType();
     if (databaseType == QDjangoDatabase::MySqlServer) {
         // starts with
         result = engine->evaluate("Q({'username__startswith': 'foobar'})");


### PR DESCRIPTION
There are two main things going on with this pull request:
- I changed the enums for dialect to a "database type" to more closely follow QSqlDriver's internal representation of database type. I'm submitting patches to Qt to make this public, after conversation with mabrand, so hopefully this will make that transition smoother in the future.
- Database type is now cached. This is a nominal improvement (latin-1 string compares vs enum compares) currently, but will show more efficiency when I submit my changes to detect database type when using the ODBC driver as that is somewhat more involved
