### PR TITLE
refactor dialect to databaseType

### DIFF
--- a/src/db/QDjango.cpp
+++ b/src/db/QDjango.cpp
@@ -61,8 +61,8 @@ static void closeDatabase()
 
 static void initDatabase(QSqlDatabase db)
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(db);
-    if (dialect == QDjangoDatabase::SQLITE) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
+    if (databaseType == QDjangoDatabase::SQLite) {
         // enable foreign key constraint handling
         QDjangoQuery query(db);
         query.prepare("PRAGMA foreign_keys=on");
@@ -161,8 +161,8 @@ QSqlDatabase QDjango::database()
 */
 void QDjango::setDatabase(QSqlDatabase database)
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(database);
-    if (dialect == QDjangoDatabase::UnknownDialect) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(database);
+    if (databaseType == QDjangoDatabase::UnknownDB) {
         qWarning() << "Unsupported database driver" << database.driverName();
     }
 
@@ -249,25 +249,25 @@ QDjangoMetaModel QDjango::registerModel(const QMetaObject *meta)
 */
 QString QDjango::noLimitSql()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::SQLITE)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::SQLite)
         return QLatin1String(" LIMIT -1");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         // 2^64 - 1, as recommended by the MySQL documentation
         return QLatin1String(" LIMIT 18446744073709551615");
 
     return QString();
 }
 
-QDjangoDatabase::Dialect QDjangoDatabase::databaseDialect(const QSqlDatabase &db)
+QDjangoDatabase::DatabaseType QDjangoDatabase::databaseType(const QSqlDatabase &db)
 {
     if (db.driverName() == QLatin1String("QMYSQL") ||
         db.driverName() == QLatin1String("QMYSQL3"))
-        return QDjangoDatabase::MYSQL;
+        return QDjangoDatabase::MySqlServer;
     else if (db.driverName() == QLatin1String("QSQLITE") ||
              db.driverName() == QLatin1String("QSQLITE2"))
-        return QDjangoDatabase::SQLITE;
+        return QDjangoDatabase::SQLite;
     else if (db.driverName() == QLatin1String("QPSQL"))
-        return QDjangoDatabase::PSQL;
-    return QDjangoDatabase::UnknownDialect;
+        return QDjangoDatabase::PostgreSQL;
+    return QDjangoDatabase::UnknownDB;
 }

--- a/src/db/QDjangoMetaModel.cpp
+++ b/src/db/QDjangoMetaModel.cpp
@@ -438,7 +438,7 @@ QStringList QDjangoMetaModel::createTableSql() const
 {
     QSqlDatabase db = QDjango::database();
     QSqlDriver *driver = db.driver();
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(db);
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
 
     QStringList queries;
     QStringList propSql;
@@ -449,13 +449,13 @@ QStringList QDjangoMetaModel::createTableSql() const
         QString fieldSql = driver->escapeIdentifier(field.column(), QSqlDriver::FieldName);
         switch (field.d->type) {
         case QVariant::Bool:
-            if (dialect == QDjangoDatabase::PSQL)
+            if (databaseType == QDjangoDatabase::PostgreSQL)
                 fieldSql += QLatin1String(" boolean");
             else
                 fieldSql += QLatin1String(" bool");
             break;
         case QVariant::ByteArray:
-            if (dialect == QDjangoDatabase::PSQL)
+            if (databaseType == QDjangoDatabase::PostgreSQL)
                 fieldSql += QLatin1String(" bytea");
             else {
                 fieldSql += QLatin1String(" blob");
@@ -467,7 +467,7 @@ QStringList QDjangoMetaModel::createTableSql() const
             fieldSql += QLatin1String(" date");
             break;
         case QVariant::DateTime:
-            if (dialect == QDjangoDatabase::PSQL)
+            if (databaseType == QDjangoDatabase::PostgreSQL)
                 fieldSql += QLatin1String(" timestamp");
             else
                 fieldSql += QLatin1String(" datetime");
@@ -506,14 +506,14 @@ QStringList QDjangoMetaModel::createTableSql() const
 
         // auto-increment is backend specific
         if (field.d->autoIncrement) {
-            if (dialect == QDjangoDatabase::SQLITE)
+            if (databaseType == QDjangoDatabase::SQLite)
                 // NOTE: django does not add this option for sqlite, but there
                 // is a ticket asking for it to do so:
                 // https://code.djangoproject.com/ticket/10164
                 fieldSql += QLatin1String(" AUTOINCREMENT");
-            else if (dialect == QDjangoDatabase::MYSQL)
+            else if (databaseType == QDjangoDatabase::MySqlServer)
                 fieldSql += QLatin1String(" AUTO_INCREMENT");
-            else if (dialect == QDjangoDatabase::PSQL)
+            else if (databaseType == QDjangoDatabase::PostgreSQL)
                 fieldSql = driver->escapeIdentifier(field.column(), QSqlDriver::FieldName) + QLatin1String(" serial PRIMARY KEY");
         }
 
@@ -522,7 +522,7 @@ QStringList QDjangoMetaModel::createTableSql() const
         {
             const QDjangoMetaModel foreignMeta = QDjango::metaModel(field.d->foreignModel);
             const QDjangoMetaField foreignField = foreignMeta.localField("pk");
-            if (dialect == QDjangoDatabase::MYSQL) {
+            if (databaseType == QDjangoDatabase::MySqlServer) {
                 QString constraintName = QString::fromLatin1("FK_%1_%2").arg(
                     field.column(), stringlist_digest(QStringList() << field.column() << d->table));
                 QString constraint =
@@ -574,7 +574,7 @@ QStringList QDjangoMetaModel::createTableSql() const
                 }
             }
 
-            if (dialect == QDjangoDatabase::PSQL)
+            if (databaseType == QDjangoDatabase::PostgreSQL)
                 fieldSql += " DEFERRABLE INITIALLY DEFERRED";
         }
         propSql << fieldSql;

--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -273,9 +273,9 @@ bool QDjangoQuerySetPrivate::sqlInsert(const QVariantMap &fields, QVariant *inse
     // fetch autoincrement pk
     if (insertId) {
         QSqlDatabase db = QDjango::database();
-        QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(db);
+        QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
 
-        if (dialect == QDjangoDatabase::PSQL) {
+        if (databaseType == QDjangoDatabase::PostgreSQL) {
             const QDjangoMetaModel metaModel = QDjango::metaModel(m_modelName);
             QDjangoQuery query(db);
             const QDjangoMetaField primaryKey = metaModel.localField("pk");

--- a/src/db/QDjangoWhere.cpp
+++ b/src/db/QDjangoWhere.cpp
@@ -300,7 +300,7 @@ bool QDjangoWhere::isNone() const
  */
 QString QDjangoWhere::sql(const QSqlDatabase &db) const
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(db);
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
 
     switch (d->operation) {
         case Equals:
@@ -332,11 +332,11 @@ QString QDjangoWhere::sql(const QSqlDatabase &db) const
         case Contains:
         {
             QString op;
-            if (dialect == QDjangoDatabase::MYSQL)
+            if (databaseType == QDjangoDatabase::MySqlServer)
                 op = QLatin1String(d->negate ? "NOT LIKE BINARY" : "LIKE BINARY");
             else
                 op = QLatin1String(d->negate ? "NOT LIKE" : "LIKE");
-            if (dialect == QDjangoDatabase::SQLITE)
+            if (databaseType == QDjangoDatabase::SQLite)
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ? ESCAPE '\\'");
             else
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ?");
@@ -347,9 +347,9 @@ QString QDjangoWhere::sql(const QSqlDatabase &db) const
         case IEquals:
         {
             const QString op = QLatin1String(d->negate ? "NOT LIKE" : "LIKE");
-            if (dialect == QDjangoDatabase::SQLITE)
+            if (databaseType == QDjangoDatabase::SQLite)
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ? ESCAPE '\\'");
-            else if (dialect == QDjangoDatabase::PSQL)
+            else if (databaseType == QDjangoDatabase::PostgreSQL)
                 return QLatin1String("UPPER(") + d->key + QLatin1String("::text) ") + op + QLatin1String(" UPPER(?)");
             else
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ?");
@@ -357,9 +357,9 @@ QString QDjangoWhere::sql(const QSqlDatabase &db) const
         case INotEquals:
         {
             const QString op = QLatin1String(d->negate ? "LIKE" : "NOT LIKE");
-            if (dialect == QDjangoDatabase::SQLITE)
+            if (databaseType == QDjangoDatabase::SQLite)
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ? ESCAPE '\\'");
-            else if (dialect == QDjangoDatabase::PSQL)
+            else if (databaseType == QDjangoDatabase::PostgreSQL)
                 return QLatin1String("UPPER(") + d->key + QLatin1String("::text) ") + op + QLatin1String(" UPPER(?)");
             else
                 return d->key + QLatin1String(" ") + op + QLatin1String(" ?");

--- a/src/db/QDjango_p.h
+++ b/src/db/QDjango_p.h
@@ -48,14 +48,19 @@ class QDjangoDatabase : public QObject
 public:
     QDjangoDatabase(QObject *parent = 0);
 
-    enum Dialect {
-        UnknownDialect,
-        SQLITE,
-        MYSQL,
-        PSQL
+    enum DatabaseType {
+        UnknownDB,
+        MSSqlServer,
+        MySqlServer,
+        PostgreSQL,
+        Oracle,
+        Sybase,
+        SQLite,
+        Interbase,
+        DB2
     };
 
-    static Dialect databaseDialect(const QSqlDatabase &db);
+    static DatabaseType databaseType(const QSqlDatabase &db);
 
     QSqlDatabase reference;
     QMutex mutex;

--- a/tests/db/qdjangometamodel/tst_qdjangometamodel.cpp
+++ b/tests/db/qdjangometamodel/tst_qdjangometamodel.cpp
@@ -116,10 +116,10 @@ void tst_QDjangoMetaModel::initTestCase()
 void tst_QDjangoMetaModel::testBool()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_bool\" (\"id\" serial PRIMARY KEY, \"value\" boolean NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_bool` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` bool NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_bool\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" bool NOT NULL)");
@@ -133,10 +133,10 @@ void tst_QDjangoMetaModel::testBool()
 void tst_QDjangoMetaModel::testByteArray()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_bytearray\" (\"id\" serial PRIMARY KEY, \"value\" bytea NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_bytearray` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` blob NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_bytearray\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" blob NOT NULL)");
@@ -150,10 +150,10 @@ void tst_QDjangoMetaModel::testByteArray()
 void tst_QDjangoMetaModel::testDate()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_date\" (\"id\" serial PRIMARY KEY, \"value\" date NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_date` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` date NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_date\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" date NOT NULL)");
@@ -166,10 +166,10 @@ void tst_QDjangoMetaModel::testDate()
 void tst_QDjangoMetaModel::testDateTime()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_datetime\" (\"id\" serial PRIMARY KEY, \"value\" timestamp NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_datetime` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` datetime NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_datetime\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" datetime NOT NULL)");
@@ -182,10 +182,10 @@ void tst_QDjangoMetaModel::testDateTime()
 void tst_QDjangoMetaModel::testDouble()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_double\" (\"id\" serial PRIMARY KEY, \"value\" real NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_double` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` real NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_double\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" real NOT NULL)");
@@ -198,10 +198,10 @@ void tst_QDjangoMetaModel::testDouble()
 void tst_QDjangoMetaModel::testInteger()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_integer\" (\"id\" serial PRIMARY KEY, \"value\" integer NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_integer` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` integer NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_integer\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" integer NOT NULL)");
@@ -216,10 +216,10 @@ void tst_QDjangoMetaModel::testInteger()
 void tst_QDjangoMetaModel::testLongLong()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_longlong\" (\"id\" serial PRIMARY KEY, \"value\" bigint NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_longlong` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` bigint NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_longlong\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" bigint NOT NULL)");
@@ -234,10 +234,10 @@ void tst_QDjangoMetaModel::testLongLong()
 void tst_QDjangoMetaModel::testString()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_string\" (\"id\" serial PRIMARY KEY, \"value\" varchar(255) NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_string` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` varchar(255) NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_string\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" varchar(255) NOT NULL)");
@@ -250,10 +250,10 @@ void tst_QDjangoMetaModel::testString()
 void tst_QDjangoMetaModel::testTime()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL)
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL)
         sql << QLatin1String("CREATE TABLE \"tst_time\" (\"id\" serial PRIMARY KEY, \"value\" time NOT NULL)");
-    else if (dialect == QDjangoDatabase::MYSQL)
+    else if (databaseType == QDjangoDatabase::MySqlServer)
         sql << QLatin1String("CREATE TABLE `tst_time` (`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, `value` time NOT NULL)");
     else
         sql << QLatin1String("CREATE TABLE \"tst_time\" (\"id\" integer NOT NULL PRIMARY KEY AUTOINCREMENT, \"value\" time NOT NULL)");
@@ -266,8 +266,8 @@ void tst_QDjangoMetaModel::testTime()
 void tst_QDjangoMetaModel::testOptions()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL) {
         sql << QLatin1String(
             "CREATE TABLE \"some_table\" ("
                 "\"id\" serial PRIMARY KEY, "
@@ -280,7 +280,7 @@ void tst_QDjangoMetaModel::testOptions()
                 "UNIQUE (\"aField\", \"b_field\")"
             ")");
         sql << QLatin1String("CREATE INDEX \"some_table_ac243651\" ON \"some_table\" (\"indexField\")");
-    } else if (dialect == QDjangoDatabase::MYSQL) {
+    } else if (databaseType == QDjangoDatabase::MySqlServer) {
         sql << QLatin1String(
             "CREATE TABLE `some_table` ("
                 "`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, "
@@ -356,8 +356,8 @@ void tst_QDjangoMetaModel::testOptions()
 void tst_QDjangoMetaModel::testConstraints()
 {
     QStringList sql;
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL) {
         sql << QLatin1String("CREATE TABLE \"tst_fkconstraint\" ("
             "\"id\" serial PRIMARY KEY, "
             "\"noConstraint_id\" integer NOT NULL REFERENCES \"user\" (\"id\") DEFERRABLE INITIALLY DEFERRED, "
@@ -369,7 +369,7 @@ void tst_QDjangoMetaModel::testConstraints()
         sql << QLatin1String("CREATE INDEX \"tst_fkconstraint_4634d592\" ON \"tst_fkconstraint\" (\"cascadeConstraint_id\")");
         sql << QLatin1String("CREATE INDEX \"tst_fkconstraint_728cefe1\" ON \"tst_fkconstraint\" (\"restrictConstraint_id\")");
         sql << QLatin1String("CREATE INDEX \"tst_fkconstraint_44c71620\" ON \"tst_fkconstraint\" (\"nullConstraint_id\")");
-    } else if (dialect == QDjangoDatabase::MYSQL) {
+    } else if (databaseType == QDjangoDatabase::MySqlServer) {
         sql << QLatin1String("CREATE TABLE `tst_fkconstraint` ("
             "`id` integer NOT NULL PRIMARY KEY AUTO_INCREMENT, "
             "`noConstraint_id` integer NOT NULL, "

--- a/tests/db/qdjangowhere/tst_qdjangowhere.cpp
+++ b/tests/db/qdjangowhere/tst_qdjangowhere.cpp
@@ -91,8 +91,8 @@ void tst_QDjangoWhere::equalsWhere()
   */
 void tst_QDjangoWhere::iEqualsWhere()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-     if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+     if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IEquals, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "abc");
 
@@ -127,8 +127,8 @@ void tst_QDjangoWhere::notEqualsWhere()
   */
 void tst_QDjangoWhere::iNotEqualsWhere()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::INotEquals, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) NOT LIKE UPPER(?)"), QVariantList() << "abc");
 
@@ -224,8 +224,8 @@ void tst_QDjangoWhere::isNull()
  */
 void tst_QDjangoWhere::startsWith()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::MYSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::MySqlServer) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::StartsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "abc%");
 
@@ -246,8 +246,8 @@ void tst_QDjangoWhere::startsWith()
 
 void tst_QDjangoWhere::iStartsWith()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IStartsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "abc%");
 
@@ -266,8 +266,8 @@ void tst_QDjangoWhere::iStartsWith()
  */
 void tst_QDjangoWhere::endsWith()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::MYSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::MySqlServer) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::EndsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "%abc");
 
@@ -287,8 +287,8 @@ void tst_QDjangoWhere::endsWith()
 
 void tst_QDjangoWhere::iEndsWith()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IEndsWith, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "%abc");
 
@@ -309,8 +309,8 @@ void tst_QDjangoWhere::iEndsWith()
  */
 void tst_QDjangoWhere::contains()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::MYSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::MySqlServer) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::Contains, "abc");
         CHECKWHERE(testQuery, QLatin1String("name LIKE BINARY ?"), QVariantList() << "%abc%");
 
@@ -330,8 +330,8 @@ void tst_QDjangoWhere::contains()
 
 void tst_QDjangoWhere::iContains()
 {
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::PSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::PostgreSQL) {
         QDjangoWhere testQuery = QDjangoWhere("name", QDjangoWhere::IContains, "abc");
         CHECKWHERE(testQuery, QLatin1String("UPPER(name::text) LIKE UPPER(?)"), QVariantList() << "%abc%");
 

--- a/tests/db/util.cpp
+++ b/tests/db/util.cpp
@@ -59,13 +59,11 @@ bool initialiseDatabase()
 
 QString normalizeSql(const QSqlDatabase &db, const QString &sql)
 {
-    QDjangoDatabase::Dialect dialect =
-        QDjangoDatabase::databaseDialect(db);
-
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(db);
     QString modSql(sql);
-    if (dialect == QDjangoDatabase::MYSQL)
+    if (databaseType == QDjangoDatabase::MySqlServer)
         modSql.replace("`", "\"");
-    else if (dialect == QDjangoDatabase::SQLITE)
+    else if (databaseType == QDjangoDatabase::SQLite)
         modSql.replace("? ESCAPE '\\'", "?");
     return modSql;
 }

--- a/tests/script/qdjangoscript/tst_qdjangoscript.cpp
+++ b/tests/script/qdjangoscript/tst_qdjangoscript.cpp
@@ -90,8 +90,8 @@ void tst_QDjangoScript::testWhereConstructor()
     where = engine->fromScriptValue<QDjangoWhere>(result);
     CHECKWHERE(where, QLatin1String("username >= ?"), QVariantList() << "foobar");
 
-    QDjangoDatabase::Dialect dialect = QDjangoDatabase::databaseDialect(QDjango::database());
-    if (dialect == QDjangoDatabase::MYSQL) {
+    QDjangoDatabase::DatabaseType databaseType = QDjangoDatabase::databaseType(QDjango::database());
+    if (databaseType == QDjangoDatabase::MySqlServer) {
         // starts with
         result = engine->evaluate("Q({'username__startswith': 'foobar'})");
         where = engine->fromScriptValue<QDjangoWhere>(result);


### PR DESCRIPTION
QSqlDriverPrivate uses a set of enums in Qt5 to represent different
database types. This changes switches to using these values internally
in QDjango, in hopes of eventually switching to the ones provided by
Qt.
