### PR TITLE
use global type cache for database types

### DIFF
--- a/src/db/QDjango.cpp
+++ b/src/db/QDjango.cpp
@@ -28,6 +28,7 @@
 
 static const char *connectionPrefix = "_qdjango_";
 
+QHash<QSqlDriver*, QDjangoDatabase::DatabaseType> QDjangoDatabase::globalTypeCache;
 QMap<QByteArray, QDjangoMetaModel> globalMetaModels = QMap<QByteArray, QDjangoMetaModel>();
 static QDjangoDatabase *globalDatabase = 0;
 static bool globalDebugEnabled = false;
@@ -261,13 +262,19 @@ QString QDjango::noLimitSql()
 
 QDjangoDatabase::DatabaseType QDjangoDatabase::databaseType(const QSqlDatabase &db)
 {
+    if (globalTypeCache.contains(db.driver()))
+        return globalTypeCache.value(db.driver());
+
+    QDjangoDatabase::DatabaseType type = QDjangoDatabase::UnknownDB;
     if (db.driverName() == QLatin1String("QMYSQL") ||
         db.driverName() == QLatin1String("QMYSQL3"))
-        return QDjangoDatabase::MySqlServer;
+        type = QDjangoDatabase::MySqlServer;
     else if (db.driverName() == QLatin1String("QSQLITE") ||
              db.driverName() == QLatin1String("QSQLITE2"))
-        return QDjangoDatabase::SQLite;
+        type = QDjangoDatabase::SQLite;
     else if (db.driverName() == QLatin1String("QPSQL"))
-        return QDjangoDatabase::PostgreSQL;
-    return QDjangoDatabase::UnknownDB;
+        type = QDjangoDatabase::PostgreSQL;
+
+    globalTypeCache.insert(db.driver(), type);
+    return type;
 }

--- a/src/db/QDjango_p.h
+++ b/src/db/QDjango_p.h
@@ -61,6 +61,7 @@ public:
     };
 
     static DatabaseType databaseType(const QSqlDatabase &db);
+    static QHash<QSqlDriver*, DatabaseType> globalTypeCache;
 
     QSqlDatabase reference;
     QMutex mutex;


### PR DESCRIPTION
This changes to using an internal globalTypeCache to determine what
the current database type is, optimizing the lookups and allowing for a potential future where
multiple databases are used in the same process
