### PR TITLE
add valid test cases for MSSqlServer order and limit generation

### DIFF
--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -174,7 +174,7 @@ QString QDjangoCompiler::orderLimitSql(const QStringList orderBy, int lowMark, i
 
     if (databaseType == QDjangoDatabase::MSSqlServer) {
         if (limit.isEmpty() && (highMark > 0 || lowMark > 0))
-            limit += QLatin1String(" ORDER BY ") + baseModel.primaryKey();
+            limit += QLatin1String(" ORDER BY ") + databaseColumn(baseModel.primaryKey());
 
         if (lowMark > 0 || (lowMark == 0 && highMark > 0)) {
             // no-limit is backend specific

--- a/tests/db/qdjangocompiler/tst_qdjangocompiler.cpp
+++ b/tests/db/qdjangocompiler/tst_qdjangocompiler.cpp
@@ -571,7 +571,7 @@ void tst_QDjangoCompiler::fieldNames_data()
 
         << "\"owner\""
            " INNER JOIN \"top\" T0 ON T0.\"owner_id\" = \"owner\".\"id\"";
-    
+
     QTest::newRow("filter multiple fields") << QByteArray("Owner") << false
         << (QStringList()
             << "\"owner\".\"id\""
@@ -628,18 +628,28 @@ void tst_QDjangoCompiler::orderLimitSql_data()
     QString sql;
 
     QTest::newRow("no order, from 0") << QStringList() << 0 << 0 << "";
-    
-    QTest::newRow("no order, from 0 to 3") << QStringList() << 0 << 3 << " LIMIT 3";
+
+    if (databaseType == QDjangoDatabase::MSSqlServer)
+        sql = " ORDER BY \"owner\".\"id\" OFFSET 0 ROWS FETCH NEXT 3 ROWS ONLY";
+    else
+        sql = " LIMIT 3";
+    QTest::newRow("no order, from 0 to 3") << QStringList() << 0 << 3 << sql;
 
     if (databaseType == QDjangoDatabase::MySqlServer)
         sql = " LIMIT 18446744073709551615 OFFSET 1";
     else if (databaseType == QDjangoDatabase::SQLite)
         sql = " LIMIT -1 OFFSET 1";
+    else if (databaseType == QDjangoDatabase::MSSqlServer)
+        sql = " ORDER BY \"owner\".\"id\" OFFSET 1 ROWS";
     else
         sql = " OFFSET 1";
     QTest::newRow("no order, from 1") << QStringList() << 1 << 0 << sql;
 
-    QTest::newRow("no order, from 1 to 3") << QStringList() << 1 << 3 << " LIMIT 2 OFFSET 1";
+    if (databaseType == QDjangoDatabase::MSSqlServer)
+        sql = " ORDER BY \"owner\".\"id\" OFFSET 1 ROWS FETCH NEXT 2 ROWS ONLY";
+    else
+        sql = " LIMIT 2 OFFSET 1";
+    QTest::newRow("no order, from 1 to 3") << QStringList() << 1 << 3 << sql;
 }
 
 void tst_QDjangoCompiler::orderLimitSql()


### PR DESCRIPTION
- added valid SQL output for generating order and limit for mssql
- changed QDjangoCompiler to use databaseColumn for ORDER BY in the mssql
  case
