### PR TITLE
Add support for pre connection hooks

### DIFF
--- a/src/db/QDjango.h
+++ b/src/db/QDjango.h
@@ -64,4 +64,7 @@ QDjangoMetaModel QDjango::registerModel()
     return registerModel(&T::staticMetaObject);
 }
 
+typedef bool (*QDjangoConnectionHook)(QSqlDatabase db);
+QDJANGO_EXPORT void qDjangoAddPreConnectionHook(QDjangoConnectionHook p);
+
 #endif


### PR DESCRIPTION
It may be desirable for the user to be able to apply certain settings
to a QSqlDatabase before use in QDjango, however, since connections are
cloned on a per-thread basis there is currently no way to do this.
Introducing pre-connection hooks allows the user to complete any neccessary
configuration of the database connection before ORM use.
