### PR TITLE
Default to fast-forward cursor for QDjangoQuery with MSSqlServer

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,15 @@ Mailing list
 ============
 
 If you wish to discuss QDjango, you are welcome to join the [QDjango group](http://groups.google.com/group/qdjango).
+
+Notes
+======
+
+MSSQL
+-----
+
+Fast forward cursors are used by default. This greatly improves performance, and has the added benefit of implicitly converting to a static cursor when it [needs to]( http://technet.microsoft.com/en-us/library/aa172573(v=sql.80).aspx). Unfortunately, this also means that these cursors can block a connection to the server. In order to deal properly with this situation, there are a few requirements:
+
+- Connection pooling must be enabled in your [ODBC manager](http://www.unixodbc.org/doc/conn_pool.html)
+- You must enable Multiple Active Result Sets in the QODBC driver using "MARS_Connection=Yes" in the connection string
+- You must enable connection pooling in the QODBC driver using the "SQL_ATTR_CONNECTION_POOLING" attribute

--- a/src/db/QDjango.cpp
+++ b/src/db/QDjango.cpp
@@ -104,6 +104,10 @@ static void initDatabase(QSqlDatabase db)
 QDjangoQuery::QDjangoQuery(QSqlDatabase db)
     : QSqlQuery(db)
 {
+    if (QDjangoDatabase::databaseType(db) == QDjangoDatabase::MSSqlServer) {
+        // default to fast-forward cursor
+        setForwardOnly(true);
+    }
 }
 
 void QDjangoQuery::addBindValue(const QVariant &val, QSql::ParamType paramType)


### PR DESCRIPTION
This is a significant performance improvement for MSSqlServer connections
using the QODBC driver. Fast-forward cursors are automatically converted
to static cursors if they meet a number of criteria (most importantly
being that the statement is not a read-only operation), so defaulting
to fast-forward gives the best of all worlds.

Interesting reading: http://technet.microsoft.com/en-us/library/aa172573(v=sql.80).aspx,
in particular the section on "Implicit Conversion of Fast Forward-only Cursors"
