### PR TITLE
Return true if table is already dropped or nonexistant

### DIFF
--- a/src/db/QDjangoMetaModel.cpp
+++ b/src/db/QDjangoMetaModel.cpp
@@ -642,10 +642,17 @@ QStringList QDjangoMetaModel::createTableSql() const
 
 /*!
     Drops the database table for this QDjangoMetaModel.
+
+    If the table never existed, or was already dropped, this method
+    will still return true.
+
+    \return true if drop query succeeded, false otherwise.
 */
 bool QDjangoMetaModel::dropTable() const
 {
     QSqlDatabase db = QDjango::database();
+    if (!db.tables().contains(d->table))
+        return true;
 
     QDjangoQuery query(db);
     return query.exec(QLatin1String("DROP TABLE ") +


### PR DESCRIPTION
Currently QDjangoMetaModel only returns success for dropTable() when
the DROP query executes properly. This changes the behavior returning
success in the event that the table is not there (either was already
dropped, or never existed)
