### PR TITLE
Transition tests to using new sorted create/dropTables

### DIFF
--- a/tests/db/auth/tst_auth.cpp
+++ b/tests/db/auth/tst_auth.cpp
@@ -59,10 +59,11 @@ private:
 void tst_Auth::initTestCase()
 {
     QVERIFY(initialiseDatabase());
-    QCOMPARE(QDjango::registerModel<User>().createTable(), true);
-    QCOMPARE(QDjango::registerModel<Group>().createTable(), true);
-    QCOMPARE(QDjango::registerModel<Message>().createTable(), true);
-    QCOMPARE(QDjango::registerModel<UserGroups>().createTable(), true);
+    QDjango::registerModel<User>();
+    QDjango::registerModel<Group>();
+    QDjango::registerModel<Message>();
+    QDjango::registerModel<UserGroups>();
+    QVERIFY(QDjango::createTables());
 }
 
 /** Load fixtures consisting of 3 users.
@@ -654,10 +655,7 @@ void tst_Auth::cleanup()
  */
 void tst_Auth::cleanupTestCase()
 {
-    QCOMPARE(QDjango::registerModel<UserGroups>().dropTable(), true);
-    QCOMPARE(QDjango::registerModel<Message>().dropTable(), true);
-    QCOMPARE(QDjango::registerModel<Group>().dropTable(), true);
-    QCOMPARE(QDjango::registerModel<User>().dropTable(), true);
+    QVERIFY(QDjango::dropTables());
 }
 
 /** Set and get foreign key on a Message object.
@@ -761,7 +759,7 @@ void tst_Auth::testGroups()
     userGroup.setUser(&user);
     userGroup.setGroup(&group);
     QCOMPARE(userGroup.save(), true);
-    
+
     UserGroups *ug = userGroups.selectRelated().get(
         QDjangoWhere("id", QDjangoWhere::Equals, 1));
     QVERIFY(ug != 0);

--- a/tests/db/qdjangomodel/tst_qdjangomodel.cpp
+++ b/tests/db/qdjangomodel/tst_qdjangomodel.cpp
@@ -120,15 +120,16 @@ private slots:
 void tst_QDjangoModel::initTestCase()
 {
     QVERIFY(initialiseDatabase());
+    QDjango::registerModel<Author>();
+    QDjango::registerModel<Book>();
+    QDjango::registerModel<BookWithNullAuthor>();
 }
 
 /** Load fixtures.
  */
 void tst_QDjangoModel::init()
 {
-    QCOMPARE(QDjango::registerModel<Author>().createTable(), true);
-    QCOMPARE(QDjango::registerModel<Book>().createTable(), true);
-    QCOMPARE(QDjango::registerModel<BookWithNullAuthor>().createTable(), true);
+    QVERIFY(QDjango::createTables());
 
     Author author1;
     author1.setName("First author");
@@ -305,9 +306,7 @@ void tst_QDjangoModel::toString()
  */
 void tst_QDjangoModel::cleanup()
 {
-    QCOMPARE(QDjango::registerModel<BookWithNullAuthor>().dropTable(), true);
-    QCOMPARE(QDjango::registerModel<Book>().dropTable(), true);
-    QCOMPARE(QDjango::registerModel<Author>().dropTable(), true);
+    QVERIFY(QDjango::dropTables());
 }
 
 /** Drop database tables after running tests.

--- a/tests/db/shares/tst_shares.cpp
+++ b/tests/db/shares/tst_shares.cpp
@@ -115,7 +115,8 @@ void File::setSize(qint64 size)
 void tst_Shares::initTestCase()
 {
     QVERIFY(initialiseDatabase());
-    QCOMPARE(QDjango::registerModel<File>().createTable(), true);
+    QDjango::registerModel<File>();
+    QVERIFY(QDjango::createTables());
 }
 
 void tst_Shares::testFile()
@@ -152,7 +153,7 @@ void tst_Shares::cleanup()
  */
 void tst_Shares::cleanupTestCase()
 {
-    QCOMPARE(QDjango::registerModel<File>().dropTable(), true);
+    QVERIFY(QDjango::dropTables());
 }
 
 QTEST_MAIN(tst_Shares)


### PR DESCRIPTION
These tests used to create their models in a certain order to avoid
conflicts during createTables(). Since we now sort the models, these
can use the same setup code as everything else.
