### PR TITLE
Add a non template member: QDjangoMetaModel QDjango::metaModel(const QOb...

### DIFF
--- a/src/db/QDjango.cpp
+++ b/src/db/QDjango.cpp
@@ -231,6 +231,16 @@ void QDjango::setDebugEnabled(bool enabled)
     globalDebugEnabled = enabled;
 }
 
+/*!
+    returns an already registered model
+
+    \sa registerModel()
+*/
+QDjangoMetaModel QDjango::metaModel(const QObject *model)
+{
+    return metaModel(model->metaObject()->className());
+}
+
 static void qdjango_topsort(const QByteArray &modelName, QHash<QByteArray, bool> &visited,
                             QStack<QDjangoMetaModel> &stack)
 {

--- a/src/db/QDjango.h
+++ b/src/db/QDjango.h
@@ -45,6 +45,7 @@ public:
 
     template <class T>
     static QDjangoMetaModel registerModel();
+    static QDjangoMetaModel metaModel(const QObject*);
 
 private:
     static QDjangoMetaModel registerModel(const QMetaObject *meta);

--- a/src/db/QDjangoMetaModel.cpp
+++ b/src/db/QDjangoMetaModel.cpp
@@ -266,7 +266,17 @@ QDjangoMetaModel::QDjangoMetaModel(const QMetaObject *meta)
     }
 
     const int count = meta->propertyCount();
-    for(int i = QObject::staticMetaObject.propertyCount(); i < count; ++i)
+    int start = 0;
+
+    for(const QMetaObject *superClass = meta; superClass; superClass = superClass->superClass())
+    {
+        start = superClass->propertyCount();
+        if(superClass->className()[0] == 'Q')
+        {
+            break;
+        }
+    }
+    for(int i = start; i < count; ++i)
     {
         const QString typeName = QString::fromLatin1(meta->property(i).typeName());
         if (!qstrcmp(meta->property(i).name(), "pk"))


### PR DESCRIPTION
Adds a non template member `QDjangoMetaModel QDjango::metaModel(const QObject *model)`

It avoids the use of template to retrieve an already registered model, and as a consequence allows one to develop a non template function that saves any QObject in database:
```C++
bool storageManager::saveItem(QObject *o)
{
    QDjangoMetaModel meta = QDjango::metaModel(o);
    if(!meta.isValid())
    {
        qWarning() << "Metamodel is not available in storageManager::saveItem for" << o->metaObject()->className();
        return false;
    }
    for(const auto &i : meta.foreignFields().keys())
    {
        meta.setForeignKey(o, i, o->property(i).value<QObject*>());
    }
    return meta.save(o);
}
```

This is especially useful when using QDjango without QDjangoModel