### PR TITLE
Only build qdjango scripting on supported versions of Qt (< 5.6)

### DIFF
--- a/examples/examples.pro
+++ b/examples/examples.pro
@@ -1,2 +1,6 @@
 TEMPLATE = subdirs
-SUBDIRS = http-server script-console
+SUBDIRS = http-server
+
+lessThan(QT_VERSION, 5.6) {
+  script-console
+}

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,5 +1,9 @@
 TEMPLATE = subdirs
 
-SUBDIRS = db http script
+SUBDIRS = db http
+
+lessThan(QT_VERSION, 5.6) {
+  SUBDIRS += script
+}
 
 CONFIG += ordered

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,2 +1,6 @@
 TEMPLATE = subdirs
-SUBDIRS = db http script
+SUBDIRS = db http
+
+lessThan(QT_VERSION, 5.6) {
+  SUBDIRS += script
+}


### PR DESCRIPTION
Fixes #44 