### PR TITLE
Added new mechanism for custom create, delete and where.

### DIFF
--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -353,12 +353,24 @@ QDjangoQuery QDjangoQuerySetPrivate::countQuery() const
     const QString where = resolvedWhere.sql(db);
     const QString limit = compiler.orderLimitSql(QStringList(), lowMark, highMark);
     QString sql = QLatin1String("SELECT COUNT(*) FROM ") + compiler.fromSql();
-    if (!where.isEmpty())
-        sql += QLatin1String(" WHERE ") + where;
+    if (!customWhere.isNull())
+    {
+       sql += QLatin1String(" WHERE ") + customWhere;
+    }
+    else if (!where.isEmpty())
+    {
+       sql += QLatin1String(" WHERE ") + where;
+    }
+
     sql += limit;
+
     QDjangoQuery query(db);
     query.prepare(sql);
-    resolvedWhere.bindValues(query);
+
+    if (customWhere.isNull())
+    {
+       resolvedWhere.bindValues(query);
+    }
 
     return query;
 }
@@ -427,12 +439,23 @@ QDjangoQuery QDjangoQuerySetPrivate::selectQuery() const
     const QString where = resolvedWhere.sql(db);
     const QString limit = compiler.orderLimitSql(orderBy, lowMark, highMark);
     QString sql = QLatin1String("SELECT ") + columns.join(QLatin1String(", ")) + QLatin1String(" FROM ") + compiler.fromSql();
-    if (!where.isEmpty())
-        sql += QLatin1String(" WHERE ") + where;
+    if (!customWhere.isNull())
+    {
+       sql += QLatin1String(" WHERE ") + customWhere;
+    }
+    else if (!where.isEmpty())
+    {
+       sql += QLatin1String(" WHERE ") + where;
+    }
     sql += limit;
     QDjangoQuery query(db);
     query.prepare(sql);
-    resolvedWhere.bindValues(query);
+    
+    if (customWhere.isNull())
+    {
+       resolvedWhere.bindValues(query);
+    }
+
     return query;
 }
 

--- a/src/db/QDjangoQuerySet.h
+++ b/src/db/QDjangoQuerySet.h
@@ -293,6 +293,7 @@ public:
     QDjangoQuerySet all() const;
     QDjangoQuerySet exclude(const QDjangoWhere &where) const;
     QDjangoQuerySet filter(const QDjangoWhere &where) const;
+    QDjangoQuerySet setCustomWhere(const QString &where) const;
     QDjangoQuerySet limit(int pos, int length = -1) const;
     QDjangoQuerySet none() const;
     QDjangoQuerySet orderBy(const QStringList &keys) const;
@@ -655,4 +656,11 @@ QDjangoQuerySet<T> &QDjangoQuerySet<T>::operator=(const QDjangoQuerySet<T> &othe
     return *this;
 }
 
+template <class T>
+QDjangoQuerySet<T> QDjangoQuerySet<T>::setCustomWhere(const QString &where) const
+{
+   QDjangoQuerySet<T> other = all();
+   other.d->customWhere = where;
+   return other;
+}
 #endif

--- a/src/db/QDjangoQuerySet_p.h
+++ b/src/db/QDjangoQuerySet_p.h
@@ -107,6 +107,7 @@ public:
     int lowMark;
     int highMark;
     QDjangoWhere whereClause;
+    QString customWhere;
     QStringList orderBy;
     QList<QVariantList> properties;
     bool selectRelated;

--- a/src/db/QDjango_p.h
+++ b/src/db/QDjango_p.h
@@ -36,6 +36,9 @@
 #  define QDJANGO_DB_EXPORT
 #endif
 
+#define CREATE_QUERY "createTable"
+#define DROP_QUERY "dropTable"
+
 /** \brief The QDjangoDatabase class represents a set of connections to a
  *  database.
  *


### PR DESCRIPTION
Added new mechanism for custom create, delete and where.
Custom create and delete need for work with views as models.
Custom where needs plenty of conditions in select.
These improvements made it possible to work with views.

For use need add to model objects Q_CLASSINFO("createTable", "<SQL>") and Q_CLASSINFO("dropTable", "<SQL>").
