### PR TITLE
added SQL aggregate functions to use with QDjangoQuerySet

### DIFF
--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -339,20 +339,24 @@ bool QDjangoQuerySetPrivate::sqlLoad(QObject *model, int index)
     return true;
 }
 
-/** Returns the SQL query to perform a COUNT on the current set.
- */
-QDjangoQuery QDjangoQuerySetPrivate::countQuery() const
-{
-    return aggregateQuery("*",QDjangoWhere::COUNT);
+static QString aggregationToString(QDjangoWhere::AggregateType type){
+    switch (type) {
+    case QDjangoWhere::AVG: return QLatin1String("AVG");
+    case QDjangoWhere::COUNT: return QLatin1String("COUNT");
+    case QDjangoWhere::SUM: return QLatin1String("SUM");
+    case QDjangoWhere::MIN: return QLatin1String("MIN");
+    case QDjangoWhere::MAX: return QLatin1String("MAX");
+    }
+    return QString();
 }
 
 /**
- * @brief QDjangoQuerySetPrivate::aggregateQuery Returns the SQL query to perform a @param field on the current set.
- * @param field name to aggregae
+ * @brief QDjangoQuerySetPrivate::aggregateQuery Returns the SQL query to perform a @param func on the current set.
+ * @param field name or expression to aggregate (eq price or amount*price)
  * @param func one of [AVG, COUNT, SUM, MIN, MAX]
  * @return SQL query to perform a @param func on the current set.
  */
-QDjangoQuery QDjangoQuerySetPrivate::aggregateQuery(const QString &field, QDjangoWhere::AggregateType func) const
+QDjangoQuery QDjangoQuerySetPrivate::aggregateQuery(const QDjangoWhere::AggregateType func, const QString &field) const
 {
     QSqlDatabase db = QDjango::database();
 
@@ -444,6 +448,7 @@ QDjangoQuery QDjangoQuerySetPrivate::selectQuery() const
     QDjangoQuery query(db);
     query.prepare(sql);
     resolvedWhere.bindValues(query);
+
     return query;
 }
 
@@ -585,14 +590,5 @@ QList<QVariantList> QDjangoQuerySetPrivate::sqlValuesList(const QStringList &fie
     return values;
 }
 
-QString QDjangoQuerySetPrivate::aggregationToString(QDjangoWhere::AggregateType type){
-    switch (type) {
-    case QDjangoWhere::AVG: return QLatin1String("AVG");
-    case QDjangoWhere::COUNT: return QLatin1String("COUNT");
-    case QDjangoWhere::SUM: return QLatin1String("SUM");
-    case QDjangoWhere::MIN: return QLatin1String("MIN");
-    case QDjangoWhere::MAX: return QLatin1String("MAX");
-    }
-    return QString();
-}
+
 /// \endcond

--- a/src/db/QDjangoQuerySet.h
+++ b/src/db/QDjangoQuerySet.h
@@ -299,6 +299,7 @@ public:
     QDjangoQuerySet selectRelated() const;
 
     int count() const;
+    QVariant aggregate(const QString& field, QDjangoWhere::AggregateType func) const;
     QDjangoWhere where() const;
 
     bool remove();
@@ -449,6 +450,20 @@ int QDjangoQuerySet<T>::count() const
     if (!query.exec() || !query.next())
         return -1;
     return query.value(0).toInt();
+}
+
+/** Counts the objects in the queryset using an SQL [AVG, COUNT, SUM, MIN, MAX] query,
+ *  or -1 if the query failed.
+ *
+ */
+template <class T>
+QVariant QDjangoQuerySet<T>::aggregate(const QString& field, QDjangoWhere::AggregateType func) const
+{
+    // execute aggregate query
+    QDjangoQuery query(d->aggregateQuery(field,func));
+    if (!query.exec() || !query.next())
+        return -1;
+    return query.value(0);
 }
 
 /** Returns a new QDjangoQuerySet containing objects for which the given key

--- a/src/db/QDjangoQuerySet.h
+++ b/src/db/QDjangoQuerySet.h
@@ -299,7 +299,7 @@ public:
     QDjangoQuerySet selectRelated() const;
 
     int count() const;
-    QVariant aggregate(const QString& field, QDjangoWhere::AggregateType func) const;
+    QVariant aggregate(const QDjangoWhere::AggregateType func, const QString& field) const;
     QDjangoWhere where() const;
 
     bool remove();
@@ -445,24 +445,21 @@ int QDjangoQuerySet<T>::count() const
     if (d->hasResults)
         return d->properties.size();
 
-    // execute COUNT query
-    QDjangoQuery query(d->countQuery());
-    if (!query.exec() || !query.next())
-        return -1;
-    return query.value(0).toInt();
+    QVariant count(aggregate(QDjangoWhere::COUNT,"*"));
+    return count.isValid() ? count.toInt() : -1;
 }
 
 /** Counts the objects in the queryset using an SQL [AVG, COUNT, SUM, MIN, MAX] query,
- *  or -1 if the query failed.
+ *  or invalid QVariant if the query failed.
  *
  */
 template <class T>
-QVariant QDjangoQuerySet<T>::aggregate(const QString& field, QDjangoWhere::AggregateType func) const
+QVariant QDjangoQuerySet<T>::aggregate(const QDjangoWhere::AggregateType func, const QString& field) const
 {
     // execute aggregate query
-    QDjangoQuery query(d->aggregateQuery(field,func));
+    QDjangoQuery query(d->aggregateQuery(func, field));
     if (!query.exec() || !query.next())
-        return -1;
+        return QVariant();
     return query.value(0);
 }
 

--- a/src/db/QDjangoQuerySet_p.h
+++ b/src/db/QDjangoQuerySet_p.h
@@ -94,15 +94,11 @@ public:
     QList<QVariantList> sqlValuesList(const QStringList &fields);
 
     // SQL queries
-    QDjangoQuery countQuery() const;
-    QDjangoQuery aggregateQuery(const QString &field, QDjangoWhere::AggregateType func) const;
+    QDjangoQuery aggregateQuery(const QDjangoWhere::AggregateType func, const QString &field) const;
     QDjangoQuery deleteQuery() const;
     QDjangoQuery insertQuery(const QVariantMap &fields) const;
     QDjangoQuery selectQuery() const;
     QDjangoQuery updateQuery(const QVariantMap &fields) const;
-
-    //static aggregate functions mapping
-    static QString aggregationToString(QDjangoWhere::AggregateType type);
 
     // reference counter
     QAtomicInt counter;

--- a/src/db/QDjangoQuerySet_p.h
+++ b/src/db/QDjangoQuerySet_p.h
@@ -95,10 +95,14 @@ public:
 
     // SQL queries
     QDjangoQuery countQuery() const;
+    QDjangoQuery aggregateQuery(const QString &field, QDjangoWhere::AggregateType func) const;
     QDjangoQuery deleteQuery() const;
     QDjangoQuery insertQuery(const QVariantMap &fields) const;
     QDjangoQuery selectQuery() const;
     QDjangoQuery updateQuery(const QVariantMap &fields) const;
+
+    //static aggregate functions mapping
+    static QString aggregationToString(QDjangoWhere::AggregateType type);
 
     // reference counter
     QAtomicInt counter;

--- a/src/db/QDjangoWhere.h
+++ b/src/db/QDjangoWhere.h
@@ -61,6 +61,13 @@ public:
         IContains
     };
 
+    enum AggregateType{
+        AVG,
+        COUNT,
+        SUM,
+        MIN,
+        MAX
+    };
     QDjangoWhere();
     QDjangoWhere(const QDjangoWhere &other);
     QDjangoWhere(const QString &key, QDjangoWhere::Operation operation, QVariant value);


### PR DESCRIPTION
hi there.
I think its very useful to make it possible to use aggregate  SQL functions on QDjangoQuerySet.
I've added AggregateType enum to QDjangoWhere, probably its not the base place for it, but it requires much less changes.