### PR TITLE
Added RANDOM as dummy field for random order in queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 qdjango.pro.user
+build*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-qdjango.pro.user
+qdjango.pro.user*
 build*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+qdjango.pro.user

--- a/src/db/QDjangoQuerySet.cpp
+++ b/src/db/QDjangoQuerySet.cpp
@@ -155,14 +155,18 @@ QString QDjangoCompiler::orderLimitSql(const QStringList &orderBy, int lowMark, 
     QStringList bits;
     QString field;
     foreach (field, orderBy) {
-        QString order = QLatin1String("ASC");
-        if (field.startsWith(QLatin1Char('-'))) {
-            order = QLatin1String("DESC");
-            field = field.mid(1);
-        } else if (field.startsWith(QLatin1Char('+'))) {
-            field = field.mid(1);
+        if (field.compare("RANDOM") == 0) {
+            bits.append("RANDOM()");
+        } else {
+            QString order = QLatin1String("ASC");
+            if (field.startsWith(QLatin1Char('-'))) {
+                order = QLatin1String("DESC");
+                field = field.mid(1);
+            } else if (field.startsWith(QLatin1Char('+'))) {
+                field = field.mid(1);
+            }
+            bits.append(databaseColumn(field) + QLatin1Char(' ') + order);
         }
-        bits.append(databaseColumn(field) + QLatin1Char(' ') + order);
     }
 
     if (!bits.isEmpty())


### PR DESCRIPTION
I recently needed to use a random ordering of query results. To avoid the call to _databaseColumn_ with a non-existing field I added a special case for using RANDOM as a field name and adding the RANDOM() call to the query.